### PR TITLE
Fix Cloudflare build and sample API

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ Run docker compose up (or docker-compose up if you rename the file).
 Docker Compose builds both images and starts both containers.
 Backend:
 
-Runs on port 3001 inside the container, exposed to the host on port 3001.
-Serves API endpoints (e.g., /api/cars).
+Runs on port 3001 inside the container (for Docker) or via Cloudflare Worker.
+Serves API endpoints such as `/api/cars` for the sample dataset.
 Frontend:
 
 React app is built into static files and served by Nginx on port 80 inside the container, mapped to port 3000 on the host.
@@ -273,7 +273,7 @@ returned.
 
 ```toml
 [build]
-command = "npm run build --prefix frontend"
+command = "npm install --prefix frontend && npm run build --prefix frontend"
 
 [site]
 bucket = "./frontend/dist"

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,32 @@ export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
+    if (url.pathname.startsWith("/api/cars")) {
+      const cars = [
+        {
+          make: 'Toyota',
+          model: 'Corolla',
+          horsepower: 139,
+          engineSize: '1.8L',
+          drivetrain: 'FWD',
+          vehicleType: 'Sedan',
+          weight: 2900
+        },
+        {
+          make: 'Ford',
+          model: 'Mustang',
+          horsepower: 450,
+          engineSize: '5.0L',
+          drivetrain: 'RWD',
+          vehicleType: 'Coupe',
+          weight: 3700
+        }
+      ];
+      return new Response(JSON.stringify(cars), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     if (url.pathname.startsWith("/api/search")) {
       const make = url.searchParams.get("make");
       const year = url.searchParams.get("year"); // optional

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,7 +36,7 @@ function App() {
   const [isLoadingModels, setIsLoadingModels] = useState(false);
 
 useEffect(() => {
-  fetch('http://localhost:3001/api/cars')
+  fetch('/api/cars')
     .then(res => res.json())
     .then(data => {
       console.log('Fetched car data:', data); // ✅ Debug line

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ main = "backend/index.js"
 compatibility_date = "2025-07-01"
 
 [build]
-command = "npm run build --prefix frontend"
+command = "npm install --prefix frontend && npm run build --prefix frontend"
 
 [site]
 bucket = "./frontend/dist"


### PR DESCRIPTION
## Summary
- install frontend deps during worker build
- expose `/api/cars` sample data from worker
- use relative API path in frontend
- clarify build command and backend notes in README

## Testing
- `npm run build --prefix frontend`
- `wrangler build`

------
https://chatgpt.com/codex/tasks/task_e_68688e4338588326925482d6e1fee8ed